### PR TITLE
Add MIT License to new work

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,8 @@
-                           CISCO SAMPLE CODE LICENSE
-                                  Version 1.1
-                Copyright (c) 2020 Cisco and/or its affiliates
+# Cisco Sample Code License
+
+   Version 1.1
+
+   Copyright (c) 2020 Cisco and/or its affiliates
 
    These terms govern this Cisco Systems, Inc. ("Cisco"), example or demo
    source code and its associated documentation (together, the "Sample

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,4 +1,29 @@
-# Cisco Sample Code License
+# LICENSES
+
+## MIT License
+
+Copyright (c) 2026 Dirk-Jan Uittenbogaard, Damien Regad
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.MIT License
+
+
+## Cisco Sample Code License
 
    Version 1.1
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,16 @@
 # Webex Space Archiver 
 
-Archives the messages of a Cisco Webex space to a single HTML file. 
+Archives the messages from Cisco Webex spaces.
+
+Copyright (c) 2020 Cisco and/or its affiliates  
+Copyright (c) 2024 Dirk-Jan Uittenbogaard  
+Copyright (c) 2026 Dirk-Jan Uittenbogaard, Damien Regad
+
+The original script (webex-space-archive.py) is released under the
+[Cisco Sample Code License](LICENSE.md#cisco-sample-code-license).
+
+The [MIT License](LICENSE.md#mit-license) applies to newer work (2024 and later).
+
 
 > [!WARNING]
 > This repository is semi actively maintained.

--- a/generate_space_batch.py
+++ b/generate_space_batch.py
@@ -1,24 +1,34 @@
-# GOAL: this code creates an .sh file which allows you to run the Webex Space Archive script
-#       for ALL of your spaces.
-# version: 0.1
-# Space archive script:     https://github.com/DJF3/Webex-Message-space-archiver/
-# How to run it? 
-#       0. install python requests ("pip3 install requests")
-#       0. check python version "python3 -V" - should be 3.10 or above
-#       0. download 'webex-space-archive.py' from the github url above.
-#       0. get your Webex dev token: https://developer.webex.com/docs/getting-your-personal-access-token (login)
-#       1. Edit this file:
-#           a. put your ACCESS_TOKEN in this variable _OR_ 
-#              (optional) set the token in an environment variable: (MacOS): export WEBEX_ARCHIVE_TOKEN='TOKENHERE'
-#           b. edit variable archive_script if the archive .py file is different than webex-space-archive.py 
-#       2. In a terminal window:         python3 generate_space_batch.py
-#              this will generate a file called "webex-space-archive-ALL.sh" and display the content.
-#       3. (optional) Edit the generated .sh script to remove spaces you don't want archived.
-#       3. Execute the generated script: sh webex-space-archive-ALL.sh
-# NOTE: that when the .sh file is executed it will use the standard .ini file for the configuration. (what to download, max files, etc)
-# Tested on Macos 14.6.1 and Python 3.12. 
-# 2025 -  DJ Uittenbogaard
-#
+"""
+Webex Message Space Archive Script.
+
+This helper script generates an .sh file which allows you to run the Archive
+script for ALL of your spaces. When the .sh file is executed, the configuration
+(what to download, max files, etc) will be retrieved from the standard .ini file.
+
+Project home: https://github.com/DJF3/Webex-Message-space-archiver
+
+Copyright (c) 2025 Dirk-Jan Uittenbogaard
+
+Released under the MIT License.
+
+Usage:
+  0. install python requests ("pip3 install requests")
+  0. check python version "python3 -V" - should be 3.10 or above
+  0. download 'webex-space-archive.py' from the github url above.
+  0. get your Webex dev token: https://developer.webex.com/docs/getting-your-personal-access-token (login)
+  1. Edit this file:
+     a. put your ACCESS_TOKEN in this variable
+        _OR_
+        set the token in the WEBEX_ARCHIVE_TOKEN environment variable:
+            export WEBEX_ARCHIVE_TOKEN='TOKENHERE' (MacOS / Linux)
+            set WEBEX_ARCHIVE_TOKEN='TOKENHERE' (Windows)
+     b. edit variable archive_script if the archive .py file is different than webex-space-archive.py
+ 2. In a terminal window, run:
+          python3 generate_space_batch.py
+    this will generate a file called "webex-space-archive-ALL.sh" and display the content.
+ 3. Edit the generated .sh script to remove spaces you don't want archived.
+ 4. Execute the generated script: sh webex-space-archive-ALL.sh
+"""
 
 from datetime import datetime
 

--- a/webex-space-archive.py
+++ b/webex-space-archive.py
@@ -1,12 +1,21 @@
 # -*- coding: utf-8 -*-
-"""Webex Message Space Archive Script.
-Creates a single HTML file with the messages of a Webex Message space
-Info/Requirements/release-notes: https://github.com/DJF3/Webex-Message-space-archiver
-Copyright (c) 2026 Cisco and/or its affiliates.
+"""
+Webex Message Space Archive Script.
+
+Creates a single HTML file with the messages of a Webex Message space.
+
+Project home: https://github.com/DJF3/Webex-Message-space-archiver
+
+Copyright (c) 2020 Cisco and/or its affiliates
+Copyright (c) 2024 Dirk-Jan Uittenbogaard
+Copyright (c) 2026 Dirk-Jan Uittenbogaard, Damien Regad
+
 This software is licensed to you under the terms of the Cisco Sample
 Code License, Version 1.1 (the "License"). You may obtain a copy of the
 License at
+
                https://developer.cisco.com/docs/licenses
+
 All use of the material herein must be in accordance with the terms of
 the License. All rights not expressly granted by the License are
 reserved. Unless required by applicable law or agreed to separately in
@@ -14,6 +23,7 @@ writing, software distributed under the License is distributed on an "AS
 IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
 or implied.
 """
+
 import json
 import datetime
 import calendar  # for DST support
@@ -46,8 +56,6 @@ except ImportError:
 __author__ = "Dirk-Jan Uittenbogaard"
 __email__ = "dirkjanu@gmail.com"
 __version__ = "0.35"
-__copyright__ = "Copyright (c) 2026 DJ Uittenbogaard."
-__license__ = "Cisco Sample Code License, Version 1.1"
 sleepTime = 3
 version = __version__
 printPerformanceReport = False


### PR DESCRIPTION
@DJF3 following up on our earlier discussion. Please review and let me know if that's OK for you.

---

The Cisco Sample Code license v 1.1 [[1]] that was used until now no longer applies to the project, as it

> should only be used by Cisco and/or its affiliates for the purpose of
> posting and sharing Cisco Sample Code.

And DJ no longer works there.

Keeping Cisco as original Copyright holder in the LICENSE file and the original Python script. Files created or significantly changed after 2024 are copyright of their original authors.

[1]: https://developer.cisco.com/docs/licenses/